### PR TITLE
e2e: add e2e test for mover

### DIFF
--- a/test/e2e/memtierd.test-suite/memtierd.source.sh
+++ b/test/e2e/memtierd.test-suite/memtierd.source.sh
@@ -27,8 +27,13 @@ memtierd-os-env() {
 }
 
 memtierd-start() {
-    vm-pipe-to-file "memtierd.yaml" <<< "${MEMTIERD_YAML}"
-    vm-command "nohup sh -c 'socat tcp4-listen:${MEMTIERD_PORT},fork,reuseaddr - | memtierd -config memtierd.yaml -debug' > ${MEMTIERD_OUTPUT} 2>&1 & sleep 2; cat ${MEMTIERD_OUTPUT}"
+    if [ -z "${MEMTIERD_YAML}" ]; then
+        MEMTIERD_OPTS="-prompt -debug"
+    else
+        vm-pipe-to-file "memtierd.yaml" <<< "${MEMTIERD_YAML}"
+        MEMTIERD_OPTS="-config memtierd.yaml -debug"
+    fi
+    vm-command "nohup sh -c 'socat tcp4-listen:${MEMTIERD_PORT},fork,reuseaddr - | memtierd ${MEMTIERD_OPTS}' > ${MEMTIERD_OUTPUT} 2>&1 & sleep 2; cat ${MEMTIERD_OUTPUT}"
     vm-command "pgrep memtierd" || {
         command-error "failed to launch memtierd"
     }

--- a/test/e2e/memtierd.test-suite/no-policy/n4c16/test01-mover/code.var.sh
+++ b/test/e2e/memtierd.test-suite/no-policy/n4c16/test01-mover/code.var.sh
@@ -1,0 +1,43 @@
+memtierd-setup
+
+# Test that 700M+ is moved to numa node {0..3} from a process
+MEME_CGROUP=e2e-meme MEME_BS=700M MEME_BWC=1 MEME_BWS=700M memtierd-meme-start
+
+next-round() {
+    local round_counter_var=$1
+    local round_counter_val=${!1}
+    local round_counter_max=$2
+    local round_delay=$3
+    if [[ "$round_counter_val" -ge "$round_counter_max" ]]; then
+        return 1
+    fi
+    eval "$round_counter_var=$(($round_counter_val + 1))"
+    sleep $round_delay
+    return 0
+}
+
+# In general, it takes around 5 seconds to finish moving out
+match-moved() {
+    local moved_regexp=$1
+    local target_numa_node=$2
+    round_number=0
+    while ! ( memtierd-command "stats -t move_pages -f csv | awk -F, \"{print \\\$6}\""; grep ${moved_regexp} <<< $COMMAND_OUTPUT); do
+        echo "grep MOVED value to the target numa node ${target_numa_node} matching ${moved_regexp} not found"
+        next-round round_number 10 1 || {
+            error "timeout: memtierd did not expected amount of memory"
+        }
+    done
+}
+
+for target_numa_node in {0..3}
+do
+  MEMTIERD_YAML=""
+  memtierd-start
+  memtierd-command "pages -pid ${MEME_PID}"
+  memtierd-command "mover -pages-to ${target_numa_node}"
+  echo "waiting 700M+ to be moved to ${target_numa_node}"
+  match-moved "${target_numa_node}\:0\.7[0-9][0-9]" ${target_numa_node}
+  memtierd-stop
+done
+
+memtierd-meme-stop

--- a/test/e2e/memtierd.test-suite/no-policy/n4c16/topology.var.json
+++ b/test/e2e/memtierd.test-suite/no-policy/n4c16/topology.var.json
@@ -1,0 +1,3 @@
+[
+    {"mem": "2G", "cores": 2, "nodes": 2, "packages": 2}
+]


### PR DESCRIPTION
- Add one more way to start memtierd, namely "memtierd -prompt", in memtierd-start() function
- Add e2e test for just mover when there is no memtierd policy